### PR TITLE
perf(layout): make slotchange event schedule a layout rather than layout immediately

### DIFF
--- a/src/lib/masonry-helpers.ts
+++ b/src/lib/masonry-helpers.ts
@@ -9,7 +9,7 @@ export type ColHeightMap = number[];
 export type MasonryCols = number | "auto";
 export type MasonryItemLayout = {top: number, left: number, col: number, colWidth: number};
 
-const DEBOUNCE_MAP: {[id: string]: number} = {};
+const DEBOUNCE_MAP = new Map<unknown, number>();
 
 /**
  * Returns an empty col height map.
@@ -84,10 +84,14 @@ export function itemPosition (i: number,
  * @param ms
  * @param id
  */
-export function debounce (cb: (() => void), ms: number, id: string) {
-	const existingTimeout = DEBOUNCE_MAP[id];
+export function debounce (cb: (() => void), ms: number, id: unknown) {
+	const existingTimeout = DEBOUNCE_MAP.get(id);
 	if (existingTimeout) window.clearTimeout(existingTimeout);
-	DEBOUNCE_MAP[id] = window.setTimeout(cb, ms);
+	const newTimeout = () => {
+		cb();
+		DEBOUNCE_MAP.delete(id);
+	};
+	DEBOUNCE_MAP.set(id, window.setTimeout(newTimeout, ms));
 }
 
 /**

--- a/src/lib/masonry-layout.ts
+++ b/src/lib/masonry-layout.ts
@@ -213,7 +213,7 @@ export class MasonryLayout extends HTMLElement {
 	 * Attaches all listeners to the element.
 	 */
 	private attachListeners () {
-		this.$slot.addEventListener("slotchange", this.layout);
+		this.$slot.addEventListener("slotchange", this.scheduleLayout);
 
 		if ("ResizeObserver" in window) {
 			this.ro = new ResizeObserver(this.didResize);
@@ -250,8 +250,8 @@ export class MasonryLayout extends HTMLElement {
 	 * Schedules a layout.
 	 * @param ms - The debounce time
 	 */
-	scheduleLayout (ms?: number) {
-		debounce(this.layout, ms || this.debounce, "layout");
+	scheduleLayout (ms?: number|Event) {
+		debounce(this.layout, typeof ms === "number" ? ms : this.debounce, this.layout);
 	}
 
 	/**


### PR DESCRIPTION
Currently, the `slotchange` event triggers an immediate layout (See [here](https://github.com/andreasbm/masonry-layout/blob/master/src/lib/masonry-layout.ts#L216)). This PR makes it call `scheduleLayout` instead. This may reduce layouts since the `slotchange` event may fire several times in a short while. In a certain other codebase you and I are both familiar with (😜) this reduced unnecessary re-layouts from 6 to 1 on one of the pages!

I also added a little debounce optimization: If there are two masonry-layouts active on a page at the same time, they would re-use the same debounce id (`"layout"`) (See [here](https://github.com/andreasbm/masonry-layout/blob/master/src/lib/masonry-layout.ts#L254). I've made it so that the id can be a function and uses the function reference as the debounce id instead.