### PR TITLE
fix(firefox): fix issue with overflowing columns in Firefox

### DIFF
--- a/src/lib/masonry-layout.ts
+++ b/src/lib/masonry-layout.ts
@@ -34,7 +34,8 @@ $template.innerHTML = `
     }
 
     .column {
-      width: calc((100% / var(${COL_COUNT_CSS_VAR_NAME}, 1)) - var(${GAP_CSS_VAR_NAME}, ${DEFAULT_GAP_PX}px));
+			max-width: calc(100% / var(${COL_COUNT_CSS_VAR_NAME}, 1));
+			width: 100%;
       flex: 1;
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
This PR fixes an issue in Firefox in masonry layouts with more than one column where the first column could exceed the given width. The fix has been tested in IE11, Chrome, Safari, and Firefox.