### PR TITLE
ESM fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 	},
 	"devDependencies": {
 		"@appnest/readme": "^1.2.7",
-		"@appnest/web-config": "0.5.0"
+		"@appnest/web-config": "0.5.0",
+		"typescript": "^5"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "2.0.8",
 	"license": "MIT",
 	"module": "index.js",
+	"type": "module",
 	"author": "Appnest",
 	"website": "https://appnest-demo.firebaseapp.com/masonry-layout/",
 	"description": "An efficient and fast web component that gives you a beautiful masonry layout",

--- a/pre-build.js
+++ b/pre-build.js
@@ -1,7 +1,10 @@
-const rimraf = require("rimraf");
-const path = require("path");
-const fs = require("fs-extra");
+import rimraf from "rimraf";
+import path from "path";
+import fs from "fs-extra";
+import url from "url";
 const outLib = "dist";
+
+const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
 // TODO: Run "tsc -p tsconfig.build.json" from this script and rename it to "build".
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,1 +1,1 @@
-export * from "./masonry-layout";
+export * from "./masonry-layout.js";

--- a/src/lib/masonry-layout.ts
+++ b/src/lib/masonry-layout.ts
@@ -179,7 +179,7 @@ export class MasonryLayout extends HTMLElement {
 		this.$unsetElementsSlot.addEventListener("slotchange", this.onSlotChange);
 
 		// Attach resize observer so we can relayout eachtime the size changes
-		if ("ResizeObserver" in window) {
+		if (window.ResizeObserver) {
 			this.ro = new ResizeObserver(this.onResize);
 			this.ro.observe(this);
 

--- a/src/lib/masonry-layout.ts
+++ b/src/lib/masonry-layout.ts
@@ -1,4 +1,4 @@
-import { COL_COUNT_CSS_VAR_NAME, ColHeightMap, debounce, DEFAULT_COLS, DEFAULT_DEBOUNCE_MS, DEFAULT_GAP_PX, DEFAULT_MAX_COL_WIDTH, ELEMENT_NODE_TYPE, findSmallestColIndex, GAP_CSS_VAR_NAME, getColCount, getNumberAttribute } from "./masonry-helpers";
+import { COL_COUNT_CSS_VAR_NAME, ColHeightMap, debounce, DEFAULT_COLS, DEFAULT_DEBOUNCE_MS, DEFAULT_GAP_PX, DEFAULT_MAX_COL_WIDTH, ELEMENT_NODE_TYPE, findSmallestColIndex, GAP_CSS_VAR_NAME, getColCount, getNumberAttribute } from "./masonry-helpers.js";
 
 /**
  * Typings required for the resize observer.

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -14,7 +14,8 @@
 			"es2017.object",
 			"es2015.proxy",
 			"esnext"
-		]
+		],
+		"skipLibCheck": true
 	},
 	"include": [
 		"src/lib/**/*"


### PR DESCRIPTION
Fixes #9 

In addition to `type: module`, the modules must all be referenced with `.js` extension. As a side note, I can highly recommend using [eslint-plugin-require-extensions](https://github.com/solana-labs/eslint-plugin-require-extensions) which ensures the extensions are used

The second commit is a little unrelated but it's the minimum I had to do to have the compilation work. Since you do not lock on a specific version of dependencies, I got type errors from `@types/babel__traverse`. Most likely caused by an old version of typescript, hence I added v5 to the dev dependencies. Let me know if you'd like this handled differently