### PR TITLE
feat: add RTL support

### DIFF
--- a/src/lib/masonry-layout.ts
+++ b/src/lib/masonry-layout.ts
@@ -46,11 +46,11 @@ $template.innerHTML = `
     }
 
     .column:not(:last-child) {
-      margin-right: var(${GAP_CSS_VAR_NAME}, ${DEFAULT_GAP_PX}px);
+      margin-inline-end: var(${GAP_CSS_VAR_NAME}, ${DEFAULT_GAP_PX}px);
     }
 
     .column ::slotted(*) {
-      margin-bottom: var(${GAP_CSS_VAR_NAME}, ${DEFAULT_GAP_PX}px);
+      margin-block-end: var(${GAP_CSS_VAR_NAME}, ${DEFAULT_GAP_PX}px);
       box-sizing: border-box;
       width: 100%;
     }


### PR DESCRIPTION
This PR implements automatic LTR/RTL support by using `margin-inline-end` instead of `margin-right`, as well as `margin-block-end` instead of `margin-bottom`.

Closes https://github.com/andreasbm/masonry-layout/issues/7

Note that [CSS Logical Properties and Values](https://drafts.csswg.org/css-logical/#propdef-margin-inline) are not supported across all browsers currently. Here's the current MDN data for browser support:

<img width="796" alt="Screenshot 2023-08-30 at 23 22 36" src="https://github.com/andreasbm/masonry-layout/assets/20454213/f04fde78-2938-42e0-9ad6-c1eea4368a33">

If you want to be backwards compatible, we can change the implementation inside `masonry-layout.ts` at line 48 to the following:

```css
.column:not(:last-child) {
    /* Fallback for browsers without support for CSS Logical Properties and Values Level 1 */
    margin-right: var(${GAP_CSS_VAR_NAME}, ${DEFAULT_GAP_PX}px);
    
    /* Set the inline-start value to zero to negate the margin-right value above when in RTL orientation */
    margin-inline-start: 0;
    margin-inline-end: var(${GAP_CSS_VAR_NAME}, ${DEFAULT_GAP_PX}px);
}

 .column ::slotted(*) {
    /* Fallback for browsers without support for CSS Logical Properties and Values Level 1 */
    margin-bottom: var(${GAP_CSS_VAR_NAME}, ${DEFAULT_GAP_PX}px);

    /* Set the inline-start value to zero to negate the margin-right value above when in RTL orientation */
    margin-block-start: 0;
    margin-block-end: var(${GAP_CSS_VAR_NAME}, ${DEFAULT_GAP_PX}px);

    box-sizing: border-box;
    width: 100%;
}
```

Then legacy user agents will pick up the initial `margin-right`/ `margin-bottom`, but ignore the declarations it doesn't support. I'm not sure if IE 11 will bug out and stop parsing the remainder of the stylesheet when it encounters a declaration it doesn't understand.

I'm not sure how forward-looking you intend Masonry Layout to be. The code in the PR does not include these fallbacks. I'll let you decide what you prefer. Thanks!